### PR TITLE
Feature/parcel and command dictionary fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-actions",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Library of JS helpers used by Aerie Actions",
   "license": "MIT",
   "homepage": "https://nasa-ammos.github.io/aerie-docs/sequencing/actions/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export function queryReadParameterDictionary(
   dbClient: PoolClient,
   id: number,
 ): Promise<QueryResult<ReadDictionaryResult>> {
-  return dbClient.query(dictionaryQuery('command_dictionary'), [id]);
+  return dbClient.query(dictionaryQuery('parameter_dictionary'), [id]);
 }
 
 export type ReadParcelResult = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export function queryListSequences(
 export type ReadCommandDictionaryResult = {
   id: number;
   dictionary_path: string;
-  command_dictionary_file_path: string;
+  dictionary_file_path: string;
   mission: string;
   version: number;
   parsed_json: any;
@@ -47,7 +47,7 @@ export function queryReadCommandDictionary(
 ): Promise<QueryResult<ReadCommandDictionaryResult>> {
   return dbClient.query(
     `
-      select id, dictionary_path, command_dictionary_file_path, mission, version, parsed_json, created_at, updated_at
+      select id, dictionary_path, dictionary_file_path, mission, version, parsed_json, created_at, updated_at
       from sequencing.command_dictionary
         where id = $1;
     `,


### PR DESCRIPTION
Renamed the `dicitonary_file_path` field to be dictionary agnostic so it is supported for channel and parameter dictionaries as well as command dictionaries.

Also bumped the version.