### PR TITLE
API support for file based workspaces

### DIFF
--- a/src/helpers/db-helpers.ts
+++ b/src/helpers/db-helpers.ts
@@ -11,13 +11,27 @@ export function dictionaryQuery(
   `;
 }
 
-export function queryReadParcel(dbClient: PoolClient, id: number): Promise<QueryResult<ReadParcelResult>> {
+export function queryReadParcel(dbClient: PoolClient, workspaceId: number): Promise<QueryResult<ReadParcelResult>> {
   return dbClient.query(
     `
-      select name, id, command_dictionary_id, channel_dictionary_id, sequence_adaptation_id, created_at, owner, updated_at, updated_by
-      from sequencing.parcel
-        where id = $1;
+      select 
+        p.name, 
+        p.id, 
+        p.command_dictionary_id, 
+        p.channel_dictionary_id, 
+        p.sequence_adaptation_id, 
+        p.created_at, 
+        p.owner, 
+        p.updated_at, 
+        p.updated_by
+      from sequencing.parcel p
+      where p.id = (
+        select parcel_id
+        from sequencing.workspace
+        where id = $1
+      );
     `,
-    [id],
+    [workspaceId],
   );
 }
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,27 +107,24 @@ export class ActionsAPI {
    * @param path - URL path to be queried
    * @param method - URL method to be used (GET, PUT, POST)
    * @param body - Request body, if needed.
-   * @param asJson - Whether the response is expected to be formatted as JSON. Defaults to true.
    * @private
    */
-  private async reqWorkspace<T = any>(
+  private async reqWorkspace(
     path: string,
     method: string,
     body: any | null = null,
-    asJson: boolean = true,
-  ): Promise<T> {
+  ): Promise<string> {
     if (!this.WORKSPACE_BASE_URL) {
       throw new Error('WORKSPACE_BASE_URL not configured');
     }
 
     const headers: HeadersInit = {};
-
     const methodsWithBody = ['POST', 'PUT'];
     let requestBody: BodyInit | undefined = undefined;
 
     if (body !== null && methodsWithBody.includes(method.toUpperCase())) {
       if (body instanceof FormData) {
-        // Don't set Content-Type; fetch will do it automatically
+        // Let fetch set Content-Type
         requestBody = body;
       } else {
         headers['Content-Type'] = 'application/json';
@@ -148,7 +145,7 @@ export class ActionsAPI {
       throw new Error(`${response.status} - ${text}`);
     }
 
-    return asJson ? JSON.parse(text) : (text as T);
+    return text;
   }
 
 
@@ -160,7 +157,7 @@ export class ActionsAPI {
     // HTTP backend - fetch workspace contents
     // Example endpoint: GET /ws/:workspaceId
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-    const data = await this.reqWorkspace<String>(fullPath, 'GET', null, false);
+    const data = await this.reqWorkspace<String>(fullPath, 'GET', null);
     if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
     return data;
   }
@@ -173,7 +170,7 @@ export class ActionsAPI {
     // HTTP backend - fetch sequence file by name
     // Example endpoint: GET /ws/:workspaceId/:name
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-    const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}', false);
+    const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}');
     if (!data) throw new Error(`File ${path} not found`);
     return data;
   }
@@ -197,8 +194,7 @@ export class ActionsAPI {
     await this.reqWorkspace(
       path,
       'PUT',
-      formData,
-      false
+      formData
     );
     return { success: true };
   }
@@ -217,8 +213,7 @@ export class ActionsAPI {
     await this.reqWorkspace(
       sourcePath,
       'POST',
-      {"copyTo": destPath},
-      false
+      {"copyTo": destPath}
     );
     return { success: true };
   }
@@ -237,8 +232,7 @@ export class ActionsAPI {
     await this.reqWorkspace(
       sourcePath,
       'POST',
-      {"moveTo": destPath},
-      false
+      {"moveTo": destPath}
     );
     return { success: true };
   }
@@ -254,8 +248,7 @@ export class ActionsAPI {
     await this.reqWorkspace(
       sourcePath,
       'DELETE',
-      {},
-      false
+      {}
     );
     return { success: true };
   }
@@ -275,8 +268,7 @@ export class ActionsAPI {
     await this.reqWorkspace(
       path,
       'PUT',
-      '{}',
-      false
+      '{}'
     );
     return { success: true };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,18 +345,18 @@ export class ActionsAPI {
     );
   }
 
+
   /**
-   * Reads a Parcel for a given id.
+   * Reads a Parcel for the current workspace.
    *
-   * @param id - The id of the Parcel.
    * @returns The parcel detail, including ids for dictionaries it contains
    */
-  async readParcel(id: number): Promise<ReadParcelResult> {
-    const result = await queryReadParcel(this.dbClient!, id);
+  async readParcel(): Promise<ReadParcelResult> {
+    const result = await queryReadParcel(this.dbClient!, this.workspaceId);
     const rows = result.rows;
 
     if (!rows.length) {
-      throw new Error(`Parcel with id: ${id} does not exist`);
+      throw new Error(`Could not find parcel for workspace id ${this.workspaceId}`);
     }
 
     return rows[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,6 +242,30 @@ export class ActionsAPI {
     }
   }
 
+  /**
+   * Move a file within the workspace to a new location.
+   * @param source - Source path of the file
+   * @param dest - Destination path of the file.
+   */
+  async moveFile(
+    source: string,
+    dest: string
+  ): Promise<any> {
+    try {
+      const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
+      const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
+      await this.reqWorkspace(
+        sourcePath,
+        'POST',
+        {"moveTo": destPath},
+        false
+      );
+      return { success: true };
+    } catch (e) {
+      throw new Error(`Failed to move file '${source}' to '${dest}': ${(e as Error).message}`);
+    }
+  }
+
 
   /**
    * Create a new directory in the given workspace filesystem.

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,10 @@ export class ActionsAPI {
     // Example endpoint: GET /ws/:workspaceId/:name
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
     const data = await this.reqWorkspace(fullPath, 'GET', '{}');
-    if (!data) throw new Error(`File ${path} not found`);
+    // Intentionally not using `if (!data)` here, as empty string is falsy
+    if (data === null || data === undefined) {
+      throw new Error(`File ${path} not found`);
+    }
     return data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,8 +188,11 @@ export class ActionsAPI {
     overwrite: boolean = false
   ): Promise<any> {
     // Example: PUT /ws/:workspaceId/:name
+    // Strip path, keep only the file name
+    const filenameOnly = name.split(/[/\\]/).pop()!;
+
     const formData = new FormData();
-    formData.append("file", new Blob([contents]), name);
+    formData.append("file", new Blob([contents]), filenameOnly);
     const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=file&overwrite=${overwrite}`;
     await this.reqWorkspace(
       path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ export class ActionsAPI {
     // HTTP backend - fetch workspace contents
     // Example endpoint: GET /ws/:workspaceId
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-    const data = await this.reqWorkspace<String>(fullPath, 'GET', null);
+    const data = await this.reqWorkspace(fullPath, 'GET', null);
     if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
     return data;
   }
@@ -170,7 +170,7 @@ export class ActionsAPI {
     // HTTP backend - fetch sequence file by name
     // Example endpoint: GET /ws/:workspaceId/:name
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-    const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}');
+    const data = await this.reqWorkspace(fullPath, 'GET', '{}');
     if (!data) throw new Error(`File ${path} not found`);
     return data;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,11 +209,10 @@ export class ActionsAPI {
     dest: string
   ): Promise<any> {
     const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
-    const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
     await this.reqWorkspace(
       sourcePath,
       'POST',
-      {"copyTo": destPath}
+      {"copyTo": dest}
     );
     return { success: true };
   }
@@ -228,11 +227,10 @@ export class ActionsAPI {
     dest: string
   ): Promise<any> {
     const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
-    const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
     await this.reqWorkspace(
       sourcePath,
       'POST',
-      {"moveTo": destPath}
+      {"moveTo": dest}
     );
     return { success: true };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,106 +76,16 @@ export function queryReadParameterDictionary(
   return dbClient.query(dictionaryQuery('parameter_dictionary'), [id]);
 }
 
-
-
-// Queries used for new file-first workspaces
-// export function queryReadFile(
-//   name: string,
-//   workspaceId: number,
-// ): Promise<QueryResult<ReadSequenceResult>> {
-//   return dbClient.query(
-//     `
-//       select name, id, workspace_id, parcel_id, definition, seq_json, owner, created_at, updated_at
-//       from sequencing.user_sequence
-//         where name = $1
-//           and workspace_id = $2;
-//     `,
-//     [name, workspaceId],
-//   );
-// }
-
-// export type ReadFileResult = {
-//   name: string;
-//   id: number;
-//   workspace_id: number;
-//   parcel_id: number;
-//   definition: string;
-//   seq_json?: string;
-//   owner?: string;
-//   created_at: string;
-//   updated_at: string;
-// };
-
-// ---
-// type for results of the Read Sequence db query
-// export type ReadSequenceResult = {
-//   name: string;
-//   id: number;
-//   workspace_id: number;
-//   parcel_id: number;
-//   definition: string;
-//   seq_json?: string;
-//   owner?: string;
-//   created_at: string;
-//   updated_at: string;
-// };
-//
-// export function queryReadSequence(
-//   dbClient: PoolClient,
-//   name: string,
-//   workspaceId: number,
-// ): Promise<QueryResult<ReadSequenceResult>> {
-//   return dbClient.query(
-//     `
-//       select name, id, workspace_id, parcel_id, definition, seq_json, owner, created_at, updated_at
-//       from sequencing.user_sequence
-//         where name = $1
-//           and workspace_id = $2;
-//     `,
-//     [name, workspaceId],
-//   );
-// }
-
-// ---
-// type for results of the Read Sequence db query
-// export type WriteSequenceResult = {};
-//
-// export function queryWriteSequence(
-//   dbClient: PoolClient,
-//   name: string,
-//   workspaceId: number,
-//   definition: string,
-//   parcelId: number,
-// ): Promise<QueryResult<WriteSequenceResult>> {
-//   // find a sequence by name, in the same workspace as the action
-//   // if it exists, overwrite its definition; else create it
-//   return dbClient.query(
-//     `
-//       WITH updated AS (
-//         UPDATE sequencing.user_sequence
-//         SET definition = $3
-//         WHERE name = $1 AND workspace_id = $2
-//         RETURNING *
-//       )
-//       -- insert sequence if we didn't successfully update
-//       INSERT INTO sequencing.user_sequence (name, workspace_id, definition, parcel_id)
-//       SELECT $1, $2, $3, $4
-//       WHERE NOT EXISTS (SELECT 1 FROM updated);
-//     `,
-//     [name, workspaceId, definition, parcelId],
-//   );
-// }
-
 // Main API class used by the user's action
 export class ActionsAPI {
+  config: ActionsConfig;
   dbClient?: PoolClient;
-  workspaceId: number;
   user: User | null;
+  workspaceId: number;
 
   ACTION_FILE_STORE: string;
   SEQUENCING_FILE_STORE: string;
   WORKSPACE_BASE_URL: string;
-  config: ActionsConfig;
 
   static ENVIRONMENT_VARIABLE_PREFIX = 'PUBLIC_ACTION_';
 
@@ -183,14 +93,14 @@ export class ActionsAPI {
    *
    * @param dbClient - A client that is part of our connection pool.
    * @param workspaceId - The id of the Workspace the Action is associated with.
-   * @param config - A config containing an `ACTION_FILE_STORE` and `SEQUENCING_FILE_STORE` so the action
-   * can read files.
+   * @param config - A config containing an `ACTION_FILE_STORE`, `SEQUENCING_FILE_STORE`, and `WORKSPACE_BASE_URL`
+   * so the action can read files.
+   * @param user - A User object for future use in authorization.
    */
   constructor(dbClient: PoolClient, workspaceId: number, config: ActionsConfig, user: User | null) {
     this.dbClient = dbClient;
     this.workspaceId = workspaceId;
     this.user = user;
-    this.dbClient = dbClient;
 
     this.ACTION_FILE_STORE = config.ACTION_FILE_STORE;
     this.SEQUENCING_FILE_STORE = config.SEQUENCING_FILE_STORE;
@@ -216,7 +126,14 @@ export class ActionsAPI {
     return undefined;
   }
 
-  // Helper to make HTTP requests to workspace service
+  /**
+   * A helper method to perform GET, PUT, and POST methods on the workspace endpoint.
+   * @param path - URL path to be queried
+   * @param method - URL method to be used (GET, PUT, POST)
+   * @param body - Request body, if needed.
+   * @param asJson - Whether the response is expected to be formatted as JSON. Defaults to true.
+   * @private
+   */
   private async reqWorkspace<T = any>(
     path: string,
     method: string,
@@ -230,13 +147,14 @@ export class ActionsAPI {
       throw new Error('User auth info required for workspace HTTP requests');
     }
 
+    // TODO: These will need to be populated in the future once action auth is supported
     const headers: HeadersInit = {
       Authorization: `Bearer ${this.user.token ?? 'TODO'}`,
       'x-hasura-role': this.user.activeRole ?? 'TODO',
       'x-hasura-user-id': this.user.id ?? 'TODO',
     };
 
-    const methodsWithBody = ['POST', 'PUT', 'PATCH'];
+    const methodsWithBody = ['POST', 'PUT'];
     let requestBody: BodyInit | undefined = undefined;
 
     if (body !== null && methodsWithBody.includes(method.toUpperCase())) {
@@ -255,8 +173,6 @@ export class ActionsAPI {
       body: requestBody,
     };
 
-    console.warn("Fetching from", `${this.WORKSPACE_BASE_URL}${path}`);
-    console.warn("Headers:", headers);
 
     try {
       const response = await fetch(`${this.WORKSPACE_BASE_URL}${path}`, options);
@@ -274,47 +190,58 @@ export class ActionsAPI {
   }
 
 
-  async listFiles(name: string): Promise<String> {
+  /**
+   * List files in the workspace at the given path.
+   * @param path - The path of the given workspace context to query
+   */
+  async listFiles(path: string): Promise<String> {
     if (this.WORKSPACE_BASE_URL) {
       // HTTP backend - fetch workspace contents
       // Example endpoint: GET /ws/:workspaceId
-      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}`;
+      const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
 
       try {
-        const data = await this.reqWorkspace<String>(path, 'GET', null);
+        const data = await this.reqWorkspace<String>(fullPath, 'GET', null, false);
         if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
         return data;
       } catch (e) {
-        throw new Error(`Failed to duh duh Node version: ${process.version}, typeof fetch: ${typeof fetch} read contents for workspace id ${this.workspaceId}: ${(e as Error).message} `);
+        throw new Error(`Failed to read contents for workspace id ${this.workspaceId}: ${(e as Error).message} `);
       }
     } else {
       throw new Error('Backend not configured to read workspace contents');
     }
   }
 
-
-  async readFile(name: string): Promise<String> {
-    console.warn ('Debugging: this.WORKSPACE_BASE_URL:' + this.WORKSPACE_BASE_URL + ' path: '+`/ws/${this.workspaceId}/${encodeURIComponent(name)}`);
+  /**
+   * Read a single file's contents in the given workspace.
+   * @param path - The path of the given workspace context to query
+   */
+  async readFile(path: string): Promise<String> {
 
     if (this.WORKSPACE_BASE_URL) {
       // HTTP backend - fetch sequence file by name
       // Example endpoint: GET /ws/:workspaceId/:name
-      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}`;
-
-      console.warn ('Attempting to query');
+      const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
 
       try {
-        const data = await this.reqWorkspace<String>(path, 'GET', '{}', false);
-        if (!data) throw new Error(`File ${name} not found`);
+        const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}', false);
+        if (!data) throw new Error(`File ${path} not found`);
         return data;
       } catch (e) {
-        throw new Error(`Failed to read file '${name}': ${(e as Error).message}`);
+        throw new Error(`Failed to read file '${path}': ${(e as Error).message}`);
       }
     } else {
       throw new Error('Backend not configured to read file');
     }
   }
 
+  /**
+   * Write a file with the given name and definition to the workspace filesystem.
+   * @param name - Full path of the file from the workspace root. This functions like mkdir -p; if parent folders
+   * do not exist, they will be created.
+   * @param definition - The contents of the file to be written.
+   * @param overwrite - If the file already exists, overwrite its contents.
+   */
   async writeFile(
     name: string,
     definition: string,
@@ -343,6 +270,11 @@ export class ActionsAPI {
     }
   }
 
+  /**
+   * Copy a file within the workspace to a new location.
+   * @param source - Source path of the file
+   * @param dest - Destination path of the file.
+   */
   async copyFile(
     source: string,
     dest: string
@@ -365,6 +297,12 @@ export class ActionsAPI {
     }
   }
 
+  /**
+   * Create a new directory in the given workspace filesystem.
+   * @param name - Name/path of the new directory.  This functions like mkdir -p; if parent folders
+   * do not exist, they will be created.
+   * @param overwrite - If the directory already exists, overwrite it.
+   */
   async createDirectory(
     name: string,
     overwrite: boolean
@@ -392,12 +330,6 @@ export class ActionsAPI {
     }
   }
 
-
-  // async listSequences(): Promise<SequenceListResult[]> {
-  //   // List all sequences in the action's workspace
-  //   const result = await queryListSequences(this.dbClient, this.workspaceId);
-  //   return result.rows;
-  // }
 
   async readChannelDictionary(id: number): Promise<ReadDictionaryResult> {
     const result = await queryReadChannelDictionary(this.dbClient!, id);
@@ -475,35 +407,6 @@ export class ActionsAPI {
     return rows[0];
   }
 
-  /**
-   * Reads a Sequence for a given Sequence name.
-   *
-   * @param name - The name of the Sequence.
-   * @returns The requested Sequence (including contents)
-   */
-  // async readSequence(name: string): Promise<ReadSequenceResult> {
-  //   const result = await queryReadSequence(this.dbClient, name, this.workspaceId);
-  //   const rows = result.rows;
-  //
-  //   if (!rows.length) {
-  //     throw new Error(`Sequence ${name} does not exist`);
-  //   }
-  //   return rows[0];
-  // }
-
-  /**
-   * Find a Sequence by name in the same Workspace as the Action, if it exists overwrite its definition otherwise
-   * create it.
-   *
-   * @param name - The name of the Sequence.
-   * @param definition - The new definition of the Sequence.
-   * @param parcelId - The Parcel id of the sequence, @defaultValue `1`.
-   * @returns The result of the attempt to write the sequence
-   */
-  // async writeSequence(name: string, definition: string, parcelId: number = 1): Promise<any> {
-  //   // TODO: rethink whether or not parcelId can have a sane default value or should be required?
-  //   return await queryWriteSequence(this.dbClient, name, this.workspaceId, definition, parcelId);
-  // }
 }
 
 /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,21 +242,18 @@ export class ActionsAPI {
     }
   }
 
+
   /**
    * Create a new directory in the given workspace filesystem.
    * @param name - Name/path of the new directory.  This functions like mkdir -p; if parent folders
-   * do not exist, they will be created.
-   * @param overwrite - If the directory already exists, overwrite it.
+   * do not exist, they will be created. If a directory already exists, it will be skipped.
    */
   async createDirectory(
-    name: string,
-    overwrite: boolean
+    name: string
   ): Promise<any> {
     // Example: PUT /ws/:workspaceId/:name
     try {
-      // const formData = new FormData();
-      // formData.append("file", new Blob([definition]), name);
-      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=directory&overwrite=${overwrite}`;
+      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=directory`;
 
       await this.reqWorkspace(
         path,
@@ -268,6 +265,17 @@ export class ActionsAPI {
     } catch (e) {
       throw new Error(`Failed to create directory '${name}': ${(e as Error).message}`);
     }
+  }
+
+  /**
+   * Create a new set of directories in the given workspace filesystem. Alias for createDirectory.
+   * @param name - Name/path of the new directory.  This functions like mkdir -p; if parent folders
+   * do not exist, they will be created. If a directory already exists, it will be skipped.
+   */
+  async createDirectories(
+    name: string
+  ): Promise<any> {
+    await this.createDirectory(name);
   }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,28 @@ export class ActionsAPI {
     }
   }
 
+  async copyFile(
+    source: string,
+    dest: string
+  ): Promise<any> {
+    if (this.WORKSPACE_BASE_URL) {
+      try {
+        const path = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
+        await this.reqWorkspace(
+          path,
+          'POST',
+          {"copyTo": dest},
+          false
+        );
+        return { success: true };
+      } catch (e) {
+        throw new Error(`Failed to copy file '${source}' to '${dest}': ${(e as Error).message}`);
+      }
+    } else {
+      throw new Error('No backend configured to copy file');
+    }
+  }
+
   async createDirectory(
     name: string,
     overwrite: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,14 +160,9 @@ export class ActionsAPI {
     // HTTP backend - fetch workspace contents
     // Example endpoint: GET /ws/:workspaceId
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-
-    try {
-      const data = await this.reqWorkspace<String>(fullPath, 'GET', null, false);
-      if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
-      return data;
-    } catch (e) {
-      throw new Error(`Failed to read contents for workspace id ${this.workspaceId}: ${(e as Error).message} `);
-    }
+    const data = await this.reqWorkspace<String>(fullPath, 'GET', null, false);
+    if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
+    return data;
   }
 
   /**
@@ -178,14 +173,9 @@ export class ActionsAPI {
     // HTTP backend - fetch sequence file by name
     // Example endpoint: GET /ws/:workspaceId/:name
     const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-
-    try {
-      const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}', false);
-      if (!data) throw new Error(`File ${path} not found`);
-      return data;
-    } catch (e) {
-      throw new Error(`Failed to read file '${path}': ${(e as Error).message}`);
-    }
+    const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}', false);
+    if (!data) throw new Error(`File ${path} not found`);
+    return data;
   }
 
   /**
@@ -201,21 +191,16 @@ export class ActionsAPI {
     overwrite: boolean = false
   ): Promise<any> {
     // Example: PUT /ws/:workspaceId/:name
-    try {
-      const formData = new FormData();
-      formData.append("file", new Blob([contents]), name);
-      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=file&overwrite=${overwrite}`;
-
-      await this.reqWorkspace(
-        path,
-        'PUT',
-        formData,
-        false
-      );
-      return { success: true };
-    } catch (e) {
-      throw new Error(`Failed to write file '${name}': ${(e as Error).message}`);
-    }
+    const formData = new FormData();
+    formData.append("file", new Blob([contents]), name);
+    const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=file&overwrite=${overwrite}`;
+    await this.reqWorkspace(
+      path,
+      'PUT',
+      formData,
+      false
+    );
+    return { success: true };
   }
 
   /**
@@ -227,19 +212,15 @@ export class ActionsAPI {
     source: string,
     dest: string
   ): Promise<any> {
-    try {
-      const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
-      const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
-      await this.reqWorkspace(
-        sourcePath,
-        'POST',
-        {"copyTo": destPath},
-        false
-      );
-      return { success: true };
-    } catch (e) {
-      throw new Error(`Failed to copy file '${source}' to '${dest}': ${(e as Error).message}`);
-    }
+    const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
+    const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
+    await this.reqWorkspace(
+      sourcePath,
+      'POST',
+      {"copyTo": destPath},
+      false
+    );
+    return { success: true };
   }
 
   /**
@@ -251,20 +232,34 @@ export class ActionsAPI {
     source: string,
     dest: string
   ): Promise<any> {
-    try {
-      const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
-      const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
-      await this.reqWorkspace(
-        sourcePath,
-        'POST',
-        {"moveTo": destPath},
-        false
-      );
-      return { success: true };
-    } catch (e) {
-      throw new Error(`Failed to move file '${source}' to '${dest}': ${(e as Error).message}`);
-    }
+    const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
+    const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
+    await this.reqWorkspace(
+      sourcePath,
+      'POST',
+      {"moveTo": destPath},
+      false
+    );
+    return { success: true };
   }
+
+  /**
+   * Delete a file or directory within the workspace to a new location.
+   * @param source - Source path of the file or directory.
+   */
+  async deleteFile(
+    source: string
+  ): Promise<any> {
+    const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
+    await this.reqWorkspace(
+      sourcePath,
+      'DELETE',
+      {},
+      false
+    );
+    return { success: true };
+  }
+
 
 
   /**
@@ -276,19 +271,14 @@ export class ActionsAPI {
     name: string
   ): Promise<any> {
     // Example: PUT /ws/:workspaceId/:name
-    try {
-      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=directory`;
-
-      await this.reqWorkspace(
-        path,
-        'PUT',
-        '{}',
-        false
-      );
-      return { success: true };
-    } catch (e) {
-      throw new Error(`Failed to create directory '${name}': ${(e as Error).message}`);
-    }
+    const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=directory`;
+    await this.reqWorkspace(
+      path,
+      'PUT',
+      '{}',
+      false
+    );
+    return { success: true };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ export class ActionsAPI {
     this.dbClient = dbClient;
     this.workspaceId = workspaceId;
     this.user = user;
+    this.config = config;
 
     this.ACTION_FILE_STORE = config.ACTION_FILE_STORE;
     this.SEQUENCING_FILE_STORE = config.SEQUENCING_FILE_STORE;

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,20 +157,16 @@ export class ActionsAPI {
    * @param path - The path of the given workspace context to query
    */
   async listFiles(path: string): Promise<String> {
-    if (this.WORKSPACE_BASE_URL) {
-      // HTTP backend - fetch workspace contents
-      // Example endpoint: GET /ws/:workspaceId
-      const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
+    // HTTP backend - fetch workspace contents
+    // Example endpoint: GET /ws/:workspaceId
+    const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
 
-      try {
-        const data = await this.reqWorkspace<String>(fullPath, 'GET', null, false);
-        if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
-        return data;
-      } catch (e) {
-        throw new Error(`Failed to read contents for workspace id ${this.workspaceId}: ${(e as Error).message} `);
-      }
-    } else {
-      throw new Error('Backend not configured to read workspace contents');
+    try {
+      const data = await this.reqWorkspace<String>(fullPath, 'GET', null, false);
+      if (!data) throw new Error(`Contents for workspace ${this.workspaceId} not found`);
+      return data;
+    } catch (e) {
+      throw new Error(`Failed to read contents for workspace id ${this.workspaceId}: ${(e as Error).message} `);
     }
   }
 
@@ -179,21 +175,16 @@ export class ActionsAPI {
    * @param path - The path of the given workspace context to query
    */
   async readFile(path: string): Promise<String> {
+    // HTTP backend - fetch sequence file by name
+    // Example endpoint: GET /ws/:workspaceId/:name
+    const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
 
-    if (this.WORKSPACE_BASE_URL) {
-      // HTTP backend - fetch sequence file by name
-      // Example endpoint: GET /ws/:workspaceId/:name
-      const fullPath = `/ws/${this.workspaceId}/${encodeURIComponent(path)}`;
-
-      try {
-        const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}', false);
-        if (!data) throw new Error(`File ${path} not found`);
-        return data;
-      } catch (e) {
-        throw new Error(`Failed to read file '${path}': ${(e as Error).message}`);
-      }
-    } else {
-      throw new Error('Backend not configured to read file');
+    try {
+      const data = await this.reqWorkspace<String>(fullPath, 'GET', '{}', false);
+      if (!data) throw new Error(`File ${path} not found`);
+      return data;
+    } catch (e) {
+      throw new Error(`Failed to read file '${path}': ${(e as Error).message}`);
     }
   }
 
@@ -209,26 +200,21 @@ export class ActionsAPI {
     contents: string,
     overwrite: boolean = false
   ): Promise<any> {
-    if (this.WORKSPACE_BASE_URL) {
-      // Example: PUT /ws/:workspaceId/:name
+    // Example: PUT /ws/:workspaceId/:name
+    try {
+      const formData = new FormData();
+      formData.append("file", new Blob([contents]), name);
+      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=file&overwrite=${overwrite}`;
 
-      try {
-        const formData = new FormData();
-        formData.append("file", new Blob([contents]), name);
-        const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=file&overwrite=${overwrite}`;
-
-        await this.reqWorkspace(
-          path,
-          'PUT',
-          formData,
-          false
-        );        
-        return { success: true };
-      } catch (e) {
-        throw new Error(`Failed to write file '${name}': ${(e as Error).message}`);
-      }
-    } else {
-      throw new Error('No backend configured to write file');
+      await this.reqWorkspace(
+        path,
+        'PUT',
+        formData,
+        false
+      );
+      return { success: true };
+    } catch (e) {
+      throw new Error(`Failed to write file '${name}': ${(e as Error).message}`);
     }
   }
 
@@ -241,22 +227,18 @@ export class ActionsAPI {
     source: string,
     dest: string
   ): Promise<any> {
-    if (this.WORKSPACE_BASE_URL) {
-      try {
-        const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
-        const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
-        await this.reqWorkspace(
-          sourcePath,
-          'POST',
-          {"copyTo": destPath},
-          false
-        );
-        return { success: true };
-      } catch (e) {
-        throw new Error(`Failed to copy file '${source}' to '${dest}': ${(e as Error).message}`);
-      }
-    } else {
-      throw new Error('No backend configured to copy file');
+    try {
+      const sourcePath = `/ws/${this.workspaceId}/${encodeURIComponent(source)}`;
+      const destPath = `/ws/${this.workspaceId}/${encodeURIComponent(dest)}`;
+      await this.reqWorkspace(
+        sourcePath,
+        'POST',
+        {"copyTo": destPath},
+        false
+      );
+      return { success: true };
+    } catch (e) {
+      throw new Error(`Failed to copy file '${source}' to '${dest}': ${(e as Error).message}`);
     }
   }
 
@@ -270,26 +252,21 @@ export class ActionsAPI {
     name: string,
     overwrite: boolean
   ): Promise<any> {
-    if (this.WORKSPACE_BASE_URL) {
-      // Example: PUT /ws/:workspaceId/:name
+    // Example: PUT /ws/:workspaceId/:name
+    try {
+      // const formData = new FormData();
+      // formData.append("file", new Blob([definition]), name);
+      const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=directory&overwrite=${overwrite}`;
 
-      try {
-        // const formData = new FormData();
-        // formData.append("file", new Blob([definition]), name);
-        const path = `/ws/${this.workspaceId}/${encodeURIComponent(name)}?type=directory&overwrite=${overwrite}`;
-
-        await this.reqWorkspace(
-          path,
-          'PUT',
-          '{}',
-          false
-        );
-        return { success: true };
-      } catch (e) {
-        throw new Error(`Failed to create directory '${name}': ${(e as Error).message}`);
-      }
-    } else {
-      throw new Error('No backend configured to create directory');
+      await this.reqWorkspace(
+        path,
+        'PUT',
+        '{}',
+        false
+      );
+      return { success: true };
+    } catch (e) {
+      throw new Error(`Failed to create directory '${name}': ${(e as Error).message}`);
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,13 +19,6 @@ export type ActionMain = (
 
 export type UserRole = string | 'aerie_admin';
 
-export type User = {
-  id: string | null;
-  token: string;
-  activeRole: UserRole;
-  allowedRoles: UserRole[];
-  defaultRole: UserRole;
-}
 export type ActionsConfig = {
   ACTION_FILE_STORE: string;
   SEQUENCING_FILE_STORE: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,16 @@ export type ActionMain = (
   actionsAPI: ActionsAPI,
 ) => Promise<ActionResult>;
 
+
+export type UserRole = string | 'aerie_admin';
+
+export type User = {
+  id: string | null;
+  token: string;
+  activeRole: UserRole;
+  allowedRoles: UserRole[];
+  defaultRole: UserRole;
+}
 export type ActionsConfig = {
   ACTION_FILE_STORE: string;
   SEQUENCING_FILE_STORE: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,5 +29,6 @@ export type User = {
 export type ActionsConfig = {
   ACTION_FILE_STORE: string;
   SEQUENCING_FILE_STORE: string;
+  WORKSPACE_BASE_URL: string;
   SECRETS?: Record<string, string>;
 };


### PR DESCRIPTION
This API update allows a user to perform queries to the new file-based workspace server. 

Important API changes are listed here. Note that the majority of these are due to the fact that sequences are now stored in the workspace filesystem, and so methods have been renamed to be more generic to reflect this.
* `listSequences` has been replaced by the more generic `listFiles`
* `readSequence` has been replaced by the more generic `readFile`
* `writeSequence` has been replaced by the more generic `writeFile`
* Addition of `createDirectory` and `copyFile` methods