### PR TITLE
Include auth header for workspace service in requests from action server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-actions",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^22.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Library of JS helpers used by Aerie Actions",
   "license": "MIT",
   "homepage": "https://nasa-ammos.github.io/aerie-docs/sequencing/actions/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,9 @@ export class ActionsAPI {
     }
 
     const headers: HeadersInit = {};
+    if(this.config.HASURA_GRAPHQL_ADMIN_SECRET) {
+      headers['x-hasura-admin-secret'] = this.config.HASURA_GRAPHQL_ADMIN_SECRET;
+    }
     const methodsWithBody = ['POST', 'PUT'];
     let requestBody: BodyInit | undefined = undefined;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,5 +23,6 @@ export type ActionsConfig = {
   ACTION_FILE_STORE: string;
   SEQUENCING_FILE_STORE: string;
   WORKSPACE_BASE_URL: string;
+  HASURA_GRAPHQL_ADMIN_SECRET: string;
   SECRETS?: Record<string, string>;
 };


### PR DESCRIPTION
Discussed with @mattdailis @cohansen @Mythicaeda - workspace server needs auth headers (either admin or user auth tokens) to perform actions. We plan to replace with a different form of actions auth in next release.