### PR TITLE
Updated the parcel query to include a list of associated parameter di…

### DIFF
--- a/src/helpers/db-helpers.ts
+++ b/src/helpers/db-helpers.ts
@@ -19,19 +19,31 @@ export function queryReadParcel(dbClient: PoolClient, workspaceId: number): Prom
         p.id, 
         p.command_dictionary_id, 
         p.channel_dictionary_id, 
+        array_agg(ppd.parameter_dictionary_id ORDER BY ppd.parameter_dictionary_id) as parameter_dictionary_ids,
         p.sequence_adaptation_id, 
         p.created_at, 
         p.owner, 
         p.updated_at, 
         p.updated_by
       from sequencing.parcel p
+      left join sequencing.parcel_to_parameter_dictionary ppd
+        on p.id = ppd.parcel_id
       where p.id = (
         select parcel_id
         from sequencing.workspace
         where id = $1
-      );
+      )
+      group by
+        p.name,
+        p.id,
+        p.command_dictionary_id,
+        p.channel_dictionary_id,
+        p.sequence_adaptation_id,
+        p.created_at,
+        p.owner,
+        p.updated_at,
+        p.updated_by;
     `,
     [workspaceId],
   );
 }
-

--- a/src/helpers/db-helpers.ts
+++ b/src/helpers/db-helpers.ts
@@ -19,7 +19,11 @@ export function queryReadParcel(dbClient: PoolClient, workspaceId: number): Prom
         p.id, 
         p.command_dictionary_id, 
         p.channel_dictionary_id, 
-        array_agg(ppd.parameter_dictionary_id ORDER BY ppd.parameter_dictionary_id) as parameter_dictionary_ids,
+        coalesce(
+            array_agg(ppd.parameter_dictionary_id order by ppd.parameter_dictionary_id)
+            filter (where ppd.parameter_dictionary_id is not null),
+            '{}'
+        ) as parameter_dictionary_ids,
         p.sequence_adaptation_id, 
         p.created_at, 
         p.owner, 

--- a/src/types/db-types.ts
+++ b/src/types/db-types.ts
@@ -14,6 +14,7 @@ export type ReadParcelResult = {
   name: string;
   command_dictionary_id: number;
   channel_dictionary_id: number;
+  parcel_dictionary_ids: number[];
   sequence_adaptation_id: number;
   created_at: string;
   owner?: string;

--- a/src/types/db-types.ts
+++ b/src/types/db-types.ts
@@ -14,7 +14,7 @@ export type ReadParcelResult = {
   name: string;
   command_dictionary_id: number;
   channel_dictionary_id: number;
-  parcel_dictionary_ids: number[];
+  parameter_dictionary_ids: number[];
   sequence_adaptation_id: number;
   created_at: string;
   owner?: string;


### PR DESCRIPTION
…ctionaries

From our thread yesterday with @parkerabercrombie, I figured I'd just fix it now before I forgot.

Parameter dictionaries are mapped so we need to include them as a list of ids in the parcel query if they exist.