### PR TITLE
update Aerie -> PlanDev/SeqDev in README and user-facing strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # aerie-actions
 
-Javascript package for use with [Aerie](https://nasa-ammos.github.io/aerie-docs/) actions.
+Javascript package for use with [SeqDev](https://nasa-ammos.github.io/plandev-docs/) actions.
 
-See [Aerie Actions docs](https://nasa-ammos.github.io/aerie-docs/sequencing/actions/) for more information - full API reference
+## Aerie -> PlanDev/SeqDev Rebrand
+
+This product was **formerly known as Aerie Actions and is now named SeqDev Actions**. While we've updated most 
+documentation and external references, some legacy mentions of the old product name may remain as we complete the transition.
+
+What to know:
+
+* The planning product, including modeling, simulation, scheduling and constraint-checking, is now named PlanDev
+* The sequencing product, including the sequence editor, workspaces, and actions, is now named SeqDev
+* All features and functionality remain the same
+* Currently, repository names, package names and other internal code references will retain their existing names, and deployment/migration procedures have not changed
+* In a future release, our repository and/or package names may change. If so, this will be communicated to users via release notes and normal communication channels
+
+For the latest documentation, visit: [PlanDev Documentation](https://nasa-ammos.github.io/plandev-docs/)
+
+<span style="display:block;text-align:center">![Example](/docs/images/Full_Example.png)</span>
+
+
+See [SeqDev Actions docs](https://nasa-ammos.github.io/plandev-docs/sequencing/actions/) for more information - full API reference
 coming soon.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-actions",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Library of JS helpers used by SeqDev Actions",
   "license": "MIT",
   "homepage": "https://nasa-ammos.github.io/aerie-docs/sequencing/actions/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nasa-jpl/aerie-actions",
   "version": "1.1.1",
-  "description": "Library of JS helpers used by Aerie Actions",
+  "description": "Library of JS helpers used by SeqDev Actions",
   "license": "MIT",
   "homepage": "https://nasa-ammos.github.io/aerie-docs/sequencing/actions/",
   "bugs": "https://github.com/NASA-AMMOS/aerie/issues",


### PR DESCRIPTION
See https://nasa-ammos.github.io/plandev-docs/introduction/ for info on rebranding effort. Don't merge until PlanDev v3.9.0 release.