### PR TITLE
Support required & variant params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-actions",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Library of JS helpers used by SeqDev Actions",
   "license": "MIT",
   "homepage": "https://nasa-ammos.github.io/aerie-docs/sequencing/actions/",

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -3,6 +3,7 @@ type ActionValueSchemaMetadata = {
   description?: string;
   required?: boolean;
   defaultValue?: any;
+  validate?: () => null | string;
 };
 
 export type ActionValueSchemaBoolean = {
@@ -62,7 +63,7 @@ export type ActionValueSchemaStruct = {
 } & ActionValueSchemaMetadata;
 
 export type Variant = {
-  key: string;
+  key: any;
   label: string;
 };
 
@@ -89,8 +90,15 @@ export type ActionValueSchema =
 export type ActionParameterDefinitions = Record<string, ActionValueSchema>;
 export type ActionSettingDefinitions = Record<string, ActionValueSchema>;
 
-// InferSchemaType is a type that resolves to the underlying value type
+// type util which, given a ParameterDefinition of a *variant* type parameter,
+// extracts all the valid variant `key` values and makes a union of them
+// (for the type of value passed into the action main function)
+type VariantKeyUnion<T extends { variants: readonly { key: unknown }[] }> =
+    T["variants"][number]["key"];
+
+// InferSchemaType is a type that resolves to the underlying value type,
 // given an ActionValueSchema as a generic
+// eg. InferSchemaType<ActionValueSchemaString> => string
 type InferSchemaType<T extends ActionValueSchema> = T extends ActionValueSchemaBoolean
   ? boolean
   : T extends ActionValueSchemaString
@@ -114,7 +122,7 @@ type InferSchemaType<T extends ActionValueSchema> = T extends ActionValueSchemaB
                     : T extends ActionValueSchemaStruct
                       ? object
                       : T extends ActionValueSchemaVariant
-                        ? Variant // ???
+                        ? VariantKeyUnion<T>
                         : never;
 
 // the type of the user's parameters/settings object


### PR DESCRIPTION
Support for required & variant type params

This was mostly already in place except for one piece: the types of the Variant values being passed to the function. These are *specified* in the action as an array of object with `key`s and `value`s, whereas only the `key` part is passed to the actual action when running - so we added a util type to extract a union of all possible variant keys.