### PR TITLE
Action report types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,56 @@ For the latest documentation, visit: [PlanDev Documentation](https://nasa-ammos.
 
 See [SeqDev Actions docs](https://nasa-ammos.github.io/plandev-docs/sequencing/actions/) for more information - full API reference
 coming soon.
+
+## Action results: `data` vs `report`
+
+An action returns an `ActionResult`:
+
+```ts
+type ActionResult = {
+  status: 'FAILED' | 'SUCCESS';
+  data: any;        // machine-readable output (rendered as raw JSON in the "Results" block)
+  report?: string;  // optional human-facing Markdown summary (rendered in the "Report" block)
+};
+```
+
+- **`data`** is the structured, machine-readable output. The UI shows it as pretty-printed JSON in the **Results** block.
+- **`report`** is an optional **Markdown** string for the things a person needs to read and click. The UI renders it in a **Report** block shown above Results — so you no longer need to stuff human-readable output into logs.
+
+### Example
+
+```ts
+export async function main(parameters, settings, actionsAPI) {
+  // ... do work ...
+  return {
+    status: 'SUCCESS',
+    data: { violations: 2, checked: 148 },
+    report: [
+      '## Constraint check complete',
+      '',
+      'Checked **148** constraints — **2 violations** found.',
+      '',
+      '| Constraint | Result |',
+      '| --- | --- |',
+      '| Power margin | OK |',
+      '| Thermal window | **Violated** at 04:12Z |',
+      '',
+      'See the [full report](https://example.com/runs/123) for details.',
+    ].join('\n'),
+  };
+}
+```
+
+### Supported Markdown
+
+The Report block accepts a curated, GitHub-flavored Markdown subset:
+
+- Headings, paragraphs, line breaks, horizontal rules
+- **Bold**, *italic*, ~~strikethrough~~, `inline code` and fenced code blocks
+- Ordered/unordered lists, blockquotes
+- Tables
+- Hyperlinks (open in a new tab)
+
+### Not supported (stripped for safety)
+
+The UI **sanitizes** report content because it is rendered in other users' browsers. The following are removed: raw HTML and inline styles (`<span>`, `style="..."`), `<script>` and event handlers, `javascript:`/`data:` links, images and video (`<img>`/`<video>`), `<iframe>`/embeds, and any markup that loads a remote resource. Treat `report` as untrusted display content — only the supported subset above is rendered.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ export async function main(parameters, settings, actionsAPI) {
     report: [
       '## Constraint check complete',
       '',
-      'Checked **148** constraints — **2 violations** found.',
+      'Checked **148** constraints — <span style="color: #c00">2 violations</span> found.',
       '',
       '| Constraint | Result |',
       '| --- | --- |',
-      '| Power margin | OK |',
-      '| Thermal window | **Violated** at 04:12Z |',
+      '| Power margin | <span style="color: green">OK</span> |',
+      '| Thermal window | <span style="color: #c00">**Violated** at 04:12Z</span> |',
       '',
       'See the [full report](https://example.com/runs/123) for details.',
     ].join('\n'),
@@ -71,7 +71,8 @@ The Report block accepts a curated, GitHub-flavored Markdown subset:
 - Ordered/unordered lists, blockquotes
 - Tables
 - Hyperlinks (open in a new tab)
+- Inline text color via `<span style="color: ...">` — `color` and `background-color` only, with validated color values (named, `#hex`, `rgb()`/`hsl()`). Works in text and inside table cells.
 
 ### Not supported (stripped for safety)
 
-The UI **sanitizes** report content because it is rendered in other users' browsers. The following are removed: raw HTML and inline styles (`<span>`, `style="..."`), `<script>` and event handlers, `javascript:`/`data:` links, images and video (`<img>`/`<video>`), `<iframe>`/embeds, and any markup that loads a remote resource. Treat `report` as untrusted display content — only the supported subset above is rendered.
+The UI **sanitizes** report content because it is rendered in other users' browsers. The following are removed: `<script>` and event handlers, `javascript:`/`data:` links, images and video (`<img>`/`<video>`), `<iframe>`/embeds, other raw HTML, and **any CSS other than `color`/`background-color`** (so a `style` can't carry `url(...)`, `position`, etc.). Treat `report` as untrusted display content — only the supported subset above is rendered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nasa-jpl/aerie-actions",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nasa-jpl/aerie-actions",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Library of JS helpers used by SeqDev Actions",
   "license": "MIT",
   "homepage": "https://nasa-ammos.github.io/aerie-docs/sequencing/actions/",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,10 +12,11 @@ export type ActionResult = {
    * legible, click-through output a person reads — links, tables, formatted text.
    *
    * Supported: headings, bold/italic/strikethrough, inline code & code blocks,
-   * lists, tables, blockquotes, horizontal rules, and hyperlinks. The UI
-   * sanitizes this content: scripts, event handlers, raw HTML (including inline
-   * styles), images, video, iframes, and any other remote-resource-loading
-   * markup are stripped.
+   * lists, tables, blockquotes, horizontal rules, hyperlinks, and inline text
+   * color via `<span style="color: ...">` (only `color`/`background-color`, with
+   * validated color values). The UI sanitizes this content: scripts, event
+   * handlers, images, video, iframes, other raw HTML, and any other CSS are
+   * stripped.
    */
   report?: string;
   [key: string]: any;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,18 @@ export * from './schema';
 export type ActionResult = {
   status: 'FAILED' | 'SUCCESS';
   data: any;
+  /**
+   * Optional human-facing summary, written in Markdown, rendered in the action
+   * run's "Report" block in the UI (above the raw Results). Use this for the
+   * legible, click-through output a person reads — links, tables, formatted text.
+   *
+   * Supported: headings, bold/italic/strikethrough, inline code & code blocks,
+   * lists, tables, blockquotes, horizontal rules, and hyperlinks. The UI
+   * sanitizes this content: scripts, event handlers, raw HTML (including inline
+   * styles), images, video, iframes, and any other remote-resource-loading
+   * markup are stripped.
+   */
+  report?: string;
   [key: string]: any;
 };
 


### PR DESCRIPTION
## Summary

Adds an optional `report` field to `ActionResult` so actions can return a human-readable Markdown summary alongside the machine-readable `data`. The SeqDev UI renders it in a new "Report" block above the raw results ([separate PR](https://github.com/NASA-AMMOS/plandev-ui/pull/1952)). Purely additive – existing actions are unaffected.

## Details

- `ActionResult.report?: string` — a Markdown string. It travels in the existing `results` payload, so no action-server or schema changes are needed.
- README now documents `data` vs `report`, the supported Markdown subset (headings, formatting, lists, tables, links, and inline text color — including in table cells), and what the UI strips for safety (scripts, images/video, iframes, raw HTML, and any CSS beyond color).

## TODO
- Update plandev-docs once these PRs merge.