### PR TITLE
Expand pattern matching to filename & extension

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -34,13 +34,15 @@ export type ActionValueSchemaSequenceList = {
 
 export type ActionValueSchemaFile = {
   type: 'file';
-  pattern?: string;
+  extensionPattern?: string;
+  filenamePattern?: string;
   primary?: boolean;
 } & ActionValueSchemaMetadata;
 
 export type ActionValueSchemaFileList = {
   type: 'fileList';
-  pattern?: string;
+  extensionPattern?: string;
+  filenamePattern?: string;
   primary?: boolean;
 } & ActionValueSchemaMetadata;
 


### PR DESCRIPTION
This PR changes the `pattern` attribute for `ActionValueSchemaFile` and `ActionValueSchemaFileList` to be split to two new options, `extensionPattern` and `filenamePattern`.

Previously, `pattern` was implemented in the UI to only be an extension matching mechanism however there are occasions where the user wants to filter down an option list based on a pattern within the filename (see: https://github.com/NASA-AMMOS/plandev-ui/issues/1872). To achieve this, `pattern` was renamed to `extensionPattern` and the `filenamePattern` was added.